### PR TITLE
Add pthread to cmake libraries

### DIFF
--- a/docker/CMakeLists.txt
+++ b/docker/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARIES
     glfw
     glm::glm
     Eigen3::Eigen
+    pthread
 )
 
 file(GLOB_RECURSE SRC LIST_DIRECTORIES false ${SOURCE_PATH}/*.cpp )


### PR DESCRIPTION
Makes `pthread` available to the linker in the docker image.